### PR TITLE
Add Range Key Support to GetItems

### DIFF
--- a/src/ServiceStack.Aws/DynamoDb/PocoDynamo.cs
+++ b/src/ServiceStack.Aws/DynamoDb/PocoDynamo.cs
@@ -332,13 +332,14 @@ namespace ServiceStack.Aws.DynamoDb
 
         const int MaxReadBatchSize = 100;
 
+        
         public List<T> GetItems<T>(IEnumerable<object> hashes)
         {
             var to = new List<T>();
 
             var table = DynamoMetadata.GetTable<T>();
-            var remainingIds = hashes.ToList();
-
+            var remainingIds = hashes.ToList();            
+            
             while (remainingIds.Count > 0)
             {
                 var batchSize = Math.Min(remainingIds.Count, MaxReadBatchSize);
@@ -350,7 +351,16 @@ namespace ServiceStack.Aws.DynamoDb
                     ConsistentRead = ConsistentRead,
                 };
                 nextBatch.Each(id =>
-                    getItems.Keys.Add(Converters.ToAttributeKeyValue(this, table.HashKey, id)));
+                {
+                    if (id is DynamoId)
+                    {
+                        getItems.Keys.Add(Converters.ToAttributeKeyValue(this, table, (DynamoId) id));
+                    }
+                    else
+                    {
+                        getItems.Keys.Add(Converters.ToAttributeKeyValue(this, table.HashKey, id));
+                    }
+                });
 
                 to.AddRange(ConvertBatchGetItemResponse<T>(table, getItems));
             }

--- a/tests/ServiceStack.Aws.DynamoDbTests/DynamoTestBase.cs
+++ b/tests/ServiceStack.Aws.DynamoDbTests/DynamoTestBase.cs
@@ -57,6 +57,24 @@ namespace ServiceStack.Aws.DynamoDbTests
             return items;
         }
 
+        public static List<RangeTest> PutRangeTests(IPocoDynamo db, int count = 10)
+        {
+            db.RegisterTable<RangeTest>();
+            db.InitSchema();
+
+            var items =
+                count.Times(
+                    i =>
+                        new RangeTest
+                        {
+                            CreatedDate = DateTime.UtcNow,
+                            Data = "Test Range",                            
+                            Id = (i + 1).ToString()
+                        });
+            db.PutItems(items);
+            return items;
+        } 
+
         protected void AssertIndex(DynamoIndex index, string indexName, string hashField, string rangeField = null)
         {
             Assert.That(index.Name, Is.EqualTo(indexName));

--- a/tests/ServiceStack.Aws.DynamoDbTests/PocoDynamoBatchTests.cs
+++ b/tests/ServiceStack.Aws.DynamoDbTests/PocoDynamoBatchTests.cs
@@ -40,6 +40,15 @@ namespace ServiceStack.Aws.DynamoDbTests
         }
 
         [Test]
+        public void Does_Batch_PutItems_and_GetItems_With_Range()
+        {
+            var db = CreatePocoDynamo();
+            var items = PutRangeTests(db);
+            var results = db.GetItems<RangeTest>(items.Map(x => new DynamoId {Hash = x.Id, Range = x.CreatedDate}));
+            Assert.That(results.OrderBy(r => r.Id), Is.EquivalentTo(items.OrderBy(i => i.Id)));
+        }
+
+        [Test]
         public void Does_Batch_PutItems_and_GetItems_handles_multiple_batches()
         {
             var db = CreatePocoDynamo();
@@ -49,6 +58,16 @@ namespace ServiceStack.Aws.DynamoDbTests
 
             Assert.That(results, Is.EquivalentTo(items));
         }
+
+        [Test]
+        public void Does_Batch_PutItems_and_GetItems_With_Range_handles_multiple_batches()
+        {
+            var db = CreatePocoDynamo();
+            var items = PutRangeTests(db, 110);
+            var results = db.GetItems<RangeTest>(items.Map(x => new DynamoId { Hash = x.Id, Range = x.CreatedDate }));
+            Assert.That(results.OrderBy(r => r.Id), Is.EquivalentTo(items.OrderBy(i => i.Id)));
+        }
+
 
         [Test]
         public void Does_Batch_DeleteItems()

--- a/tests/ServiceStack.Aws.DynamoDbTests/RangeKeyTests.cs
+++ b/tests/ServiceStack.Aws.DynamoDbTests/RangeKeyTests.cs
@@ -15,6 +15,29 @@ namespace ServiceStack.Aws.DynamoDbTests
 
         public string Data { get; set; }
         public DateTime? ExpiryDate { get; set; }
+
+        protected bool Equals(RangeTest other)
+        {
+            
+            var datesCloseEnough = Math.Abs(CreatedDate.Subtract(other.CreatedDate).TotalSeconds) < 1;
+            return Id == other.Id && datesCloseEnough && string.Equals(Data, other.Data);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((RangeTest)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Id.GetHashCode() * 397) ^ (CreatedDate != null ? CreatedDate.GetHashCode() : 0);
+            }
+        }
     }
 
     public class RangeKeyTests : DynamoTestBase


### PR DESCRIPTION
I didn't see a way to execute a batched GetItem request with a Hash + Range key in the current API. 