### PR TITLE
Throw exception when HashKey cannot be found

### DIFF
--- a/src/ServiceStack.Aws/DynamoDb/DynamoConverters.cs
+++ b/src/ServiceStack.Aws/DynamoDb/DynamoConverters.cs
@@ -140,7 +140,8 @@ namespace ServiceStack.Aws.DynamoDb
                 else
                 {
                     //Otherwise set the Id as the hash key if hash key is not explicitly defined
-                    hash = GetPrimaryKey(props) ?? props[0];
+                    hash = GetPrimaryKey(props);
+                    if(hash == null) throw new ArgumentException("Could not determine which property should be the Hash Key. Please refer to https://github.com/ServiceStack/PocoDynamo#table-definition for details on defining hash and range keys.");
                 }
             }
         }


### PR DESCRIPTION
I was attempting to setup some base objects for a lookup table in DynamoDB, and to do this I used a class structure which utilized read-only calculated Hash and Range Keys. The idea was the Hash and Range keys followed certain patterns dictated by the type of object and its child properties, and this would allow me to easily store all of this data in a single Dynamo table. 

After running into some errors on a `GetItem` operation I learned that the PocoDynamo code which searches for the `HashKey` and `RangeKey` attributes won't work on read-only properties. This led to PocoDynamo making an incorrect guess for a `HashKey`.

I would have preferred PocoDynamo to have thrown an error informing me it couldn't determine my key structure, instead of assigning `props[0]` as the HashKey.

So my recommendation is to throw an error at that point, with a message linking to the documentation on setting up keys. The list of ways to explicitly specify Hash and Range keys are already very flexible and forgiving that should render this "fail-safe" guess unnecessary.
