### PR TITLE
Added 3 Asserts to Does_resolve_nested_files_and_folders() test

### DIFF
--- a/tests/ServiceStack.Aws.Tests/S3/VirtualPathProviderTests.cs
+++ b/tests/ServiceStack.Aws.Tests/S3/VirtualPathProviderTests.cs
@@ -257,6 +257,10 @@ namespace ServiceStack.Aws.Tests.S3
             Assert.That(pathProvider.GetDirectory("a/b").GetFile("c/testfile-abc1.txt").ReadAllText(), Is.EqualTo("testfile-abc1"));
             Assert.That(pathProvider.GetDirectory("a").GetDirectory("b").GetDirectory("c").GetFile("testfile-abc1.txt").ReadAllText(), Is.EqualTo("testfile-abc1"));
 
+            Assert.That(pathProvider.GetDirectory("a/b/c").GetAllMatchingFiles("testfile-abc1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b").GetAllMatchingFiles("testfile-abc1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a").GetAllMatchingFiles("testfile-abc1.txt").Count(), Is.EqualTo(1));
+            
             var dirs = pathProvider.RootDirectory.Directories.Map(x => x.VirtualPath);
             Assert.That(dirs, Is.EquivalentTo(new[] { "a", "e" }));
 


### PR DESCRIPTION
I found an issue using the GetAllMatchingFiles() when the file is more than two levels away, regardless of the max depth value.