### PR TITLE
Added more depth to reproduce error in this test.

### DIFF
--- a/tests/ServiceStack.Aws.Tests/S3/VirtualPathProviderTests.cs
+++ b/tests/ServiceStack.Aws.Tests/S3/VirtualPathProviderTests.cs
@@ -196,7 +196,7 @@ namespace ServiceStack.Aws.Tests.S3
                 "a/b/c/testfile-abc2.txt",
                 "a/d/testfile-ad1.txt",
                 "e/testfile-e1.txt",
-                "a/b/c/x/y/z/testfile-abcxyz1.txt",
+                "a/b/c/d/e/f/g/testfile-abcdefg1.txt",
             };
 
             allFilePaths.Each(x => pathProvider.WriteFile(x, x.SplitOnLast('.').First().SplitOnLast('/').Last()));
@@ -258,12 +258,13 @@ namespace ServiceStack.Aws.Tests.S3
             Assert.That(pathProvider.GetDirectory("a/b").GetFile("c/testfile-abc1.txt").ReadAllText(), Is.EqualTo("testfile-abc1"));
             Assert.That(pathProvider.GetDirectory("a").GetDirectory("b").GetDirectory("c").GetFile("testfile-abc1.txt").ReadAllText(), Is.EqualTo("testfile-abc1"));
 
-            Assert.That(pathProvider.GetDirectory("a/b/c/x/y/z").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
-            Assert.That(pathProvider.GetDirectory("a/b/c/x/y").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
-            Assert.That(pathProvider.GetDirectory("a/b/c/x").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
-            Assert.That(pathProvider.GetDirectory("a/b/c").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
-            Assert.That(pathProvider.GetDirectory("a/b").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
-            Assert.That(pathProvider.GetDirectory("a").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b/c/d/e/f/g").GetAllMatchingFiles("testfile-abcdefg1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b/c/d/e/f").GetAllMatchingFiles("testfile-abcdefg1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b/c/d/e").GetAllMatchingFiles("testfile-abcdefg1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b/c/d").GetAllMatchingFiles("testfile-abcdefg1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b/c").GetAllMatchingFiles("testfile-abcdefg1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b").GetAllMatchingFiles("testfile-abcdefg1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a").GetAllMatchingFiles("testfile-abcdefg1.txt").Count(), Is.EqualTo(1));
             
             var dirs = pathProvider.RootDirectory.Directories.Map(x => x.VirtualPath);
             Assert.That(dirs, Is.EquivalentTo(new[] { "a", "e" }));

--- a/tests/ServiceStack.Aws.Tests/S3/VirtualPathProviderTests.cs
+++ b/tests/ServiceStack.Aws.Tests/S3/VirtualPathProviderTests.cs
@@ -196,6 +196,7 @@ namespace ServiceStack.Aws.Tests.S3
                 "a/b/c/testfile-abc2.txt",
                 "a/d/testfile-ad1.txt",
                 "e/testfile-e1.txt",
+                "a/b/c/x/y/z/testfile-abcxyz1.txt",
             };
 
             allFilePaths.Each(x => pathProvider.WriteFile(x, x.SplitOnLast('.').First().SplitOnLast('/').Last()));
@@ -257,9 +258,12 @@ namespace ServiceStack.Aws.Tests.S3
             Assert.That(pathProvider.GetDirectory("a/b").GetFile("c/testfile-abc1.txt").ReadAllText(), Is.EqualTo("testfile-abc1"));
             Assert.That(pathProvider.GetDirectory("a").GetDirectory("b").GetDirectory("c").GetFile("testfile-abc1.txt").ReadAllText(), Is.EqualTo("testfile-abc1"));
 
-            Assert.That(pathProvider.GetDirectory("a/b/c").GetAllMatchingFiles("testfile-abc1.txt").Count(), Is.EqualTo(1));
-            Assert.That(pathProvider.GetDirectory("a/b").GetAllMatchingFiles("testfile-abc1.txt").Count(), Is.EqualTo(1));
-            Assert.That(pathProvider.GetDirectory("a").GetAllMatchingFiles("testfile-abc1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b/c/x/y/z").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b/c/x/y").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b/c/x").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b/c").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a").GetAllMatchingFiles("testfile-abcxyz1.txt").Count(), Is.EqualTo(1));
             
             var dirs = pathProvider.RootDirectory.Directories.Map(x => x.VirtualPath);
             Assert.That(dirs, Is.EquivalentTo(new[] { "a", "e" }));

--- a/tests/ServiceStack.Aws.Tests/S3/VirtualPathProviderTests.cs
+++ b/tests/ServiceStack.Aws.Tests/S3/VirtualPathProviderTests.cs
@@ -257,6 +257,10 @@ namespace ServiceStack.Aws.Tests.S3
             Assert.That(pathProvider.GetDirectory("a/b").GetFile("c/testfile-abc1.txt").ReadAllText(), Is.EqualTo("testfile-abc1"));
             Assert.That(pathProvider.GetDirectory("a").GetDirectory("b").GetDirectory("c").GetFile("testfile-abc1.txt").ReadAllText(), Is.EqualTo("testfile-abc1"));
 
+            Assert.That(pathProvider.GetDirectory("a/b/c").GetAllMatchingFiles("testfile-abc1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a/b").GetAllMatchingFiles("testfile-abc1.txt").Count(), Is.EqualTo(1));
+            Assert.That(pathProvider.GetDirectory("a").GetAllMatchingFiles("testfile-abc1.txt").Count(), Is.EqualTo(1));
+            
             var dirs = pathProvider.RootDirectory.Directories.Map(x => x.VirtualPath);
             Assert.That(dirs, Is.EquivalentTo(new[] { "a", "e" }));
 


### PR DESCRIPTION
ServiceStack.Aws.Tests.S3.S3VirtualPathProviderTests.Does_resolve_nested_files_and_folders

  Expected: 1
  But was:  0

   at ServiceStack.Aws.Tests.S3.VirtualPathProviderTests.Does_resolve_nested_files_and_folders()