### PR TITLE
Update DynamoMetadata.cs

### DIFF
--- a/src/ServiceStack.Aws/DynamoDb/DynamoMetadata.cs
+++ b/src/ServiceStack.Aws/DynamoDb/DynamoMetadata.cs
@@ -119,7 +119,8 @@ namespace ServiceStack.Aws.DynamoDb
             var table = ToMetadataTable(type);
             Types.Add(table);
 
-            LicenseUtils.AssertValidUsage(LicenseFeature.Aws, QuotaType.Tables, Types.Count);
+            //using table count to fix limit reached issue. or else it restricts the poco types to 10
+            LicenseUtils.AssertValidUsage(LicenseFeature.Aws, QuotaType.Tables, GetTables().Count);
 
             RegisterTypes(type.GetReferencedTypes());
 


### PR DESCRIPTION
fixed issue where registering more than 10 poco types at startup throws LicenseException.

Corrected license validation to pick only tables to check if limit is reached or not.